### PR TITLE
Use poetry cache in workflows

### DIFF
--- a/.github/actions/mkdocs-cache/action.yaml
+++ b/.github/actions/mkdocs-cache/action.yaml
@@ -1,0 +1,13 @@
+name: mkdocs-cache
+description: Cache mkdocs
+runs:
+  using: composite
+  steps:
+    - run: pipx install poetry
+      shell: bash
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3.x
+        cache: poetry
+    - run: poetry install --only mkdocs
+      shell: bash

--- a/.github/workflows/mkdocs-build.yaml
+++ b/.github/workflows/mkdocs-build.yaml
@@ -7,10 +7,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: pipx install poetry
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-          cache: poetry
-      - run: poetry install --only mkdocs
+      - uses: ./.github/actions/mkdocs-cache
       - run: poetry run mkdocs build

--- a/.github/workflows/mkdocs-deploy.yaml
+++ b/.github/workflows/mkdocs-deploy.yaml
@@ -9,15 +9,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      # same as build
       - uses: actions/checkout@v4
-      - run: pipx install poetry
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-          cache: poetry
-      - run: poetry install --only mkdocs
-      # also deploy
+      - uses: ./.github/actions/mkdocs-cache
       - name: Configure Git Credentials
         run: |
           git config user.name github-actions[bot]

--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ The `.gitignore` in this repo has just one entry, `site/`, which is the default 
 ### Optional things
 
 - `docs/api.md` gives you an example of how to use [mkdocstrings](https://mkdocstrings.github.io/) to generate API documentation from doc strings.
-- There are two `.github/workflows/`:
-  - `mkdocs-build.yaml`: On each PR, check that `mkdocs build` runs without error. Assumes you are using poetry.
-  - `mkdocs-deploy.yaml`: On pushes to `main`, use `mkdocs gh-deploy` to update the repo's GitHub Pages.
+- GitHub continuous integration:
+  - `.github/actions/mkdocs-cache/action.yaml`: Cache the poetry environment needed to run mkdocs. Used by the two workflows.
+  - `.github/workflows/mkdocs-build.yaml`: On each PR, check that `mkdocs build` runs without error. Assumes you are using poetry.
+  - `.github/workflows/mkdocs-deploy.yaml`: On pushes to `main`, use `mkdocs gh-deploy` to update the repo's GitHub Pages.
 
 ### For internal use only
 


### PR DESCRIPTION
- Use a custom action that is in common to the two workflows
- Use the built-in poetry caching, so that the only thing being done each time is to `poetry install` from the existing cache
- Leave the mkdocs deploy credentials inside the deploy workflow, rather than the common action

See https://github.com/cdcent/cfa-mkdocs-template/actions/runs/13401591240/job/37433450487#step:3:49 for the caching. It shows that nothing is actually being done when `poetry install` is called, because we can just fall back on the cache.

Resolves #7 
Resolves #4 