### PR TITLE
Fix pull path option

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -20,8 +20,9 @@ plugins:
       handlers:
         python:
           options:
+            # see <https://mkdocstrings.github.io/python/usage/> for options
             show_root_heading: true
-            show_full_root_path: true
+            show_object_full_path: true
   - search
 
 markdown_extensions:


### PR DESCRIPTION
Resolves #8

The old `show_full_root_path` was a typo (it's `show_root_full_path`), which is why the warning in #8 was thrown. It also wasn't actually what I wanted, thus `show_object_full_path`.